### PR TITLE
Fix code example

### DIFF
--- a/Scaling-Reads.md
+++ b/Scaling-Reads.md
@@ -93,7 +93,7 @@ Also, we want to read from master by default so have to patch Makara. Create an 
 ```ruby
 Makara::Cache.store = :noop
 
-class DefaultToMasterPool
+module DefaultToMasterPool
   def _appropriate_pool(*args)
     return @master_pool unless Thread.current[:distribute_reads]
     super


### PR DESCRIPTION
Module#prepend only accepts a module. Otherwise this code will throw: `'prepend': wrong argument type Class (expected Module) (TypeError)`