### PR TITLE
Flesh out the pgbouncer instructions for EC2

### DIFF
--- a/PgBouncer-Setup.md
+++ b/PgBouncer-Setup.md
@@ -16,7 +16,11 @@ You can install PgBouncer on the same server as Postgres or a separate server. F
 Web app -> EC2 running PgBouncer -> RDS instance
 ```
 
-Start by launching a new instance of Ubuntu Server 16.04 LTS. Once the server is ready, ssh in. For the latest version of PgBouncer, we’ll use the [official Postgres APT repository](https://wiki.postgresql.org/wiki/Apt).
+Start by launching a new instance of Ubuntu Server 16.04 LTS. Be sure to open inbound TCP port 6432 in the security group associated with your instance, and confirm that it's reachable from any IPs you'll be using with it.
+
+(You might also want to lock down the security group inbound TCP rule that governs your RDS instance, so that it can accept incoming postgres connections only from the IP that the pgbouncer ec2 instance is on, but be sure that you've reserved an IP for this instance, first.)
+
+Once the server is ready, ssh in. For the latest version of PgBouncer, we’ll use the [official Postgres APT repository](https://wiki.postgresql.org/wiki/Apt).
 
 ```sh
 sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
@@ -31,7 +35,7 @@ Edit `/etc/pgbouncer/pgbouncer.ini`. The important settings are:
 
 ```ini
 [databases]
-YOUR-DBNAME = host=YOUR-HOST port=5432 dbname=YOUR-DBNAME
+YOUR-DBNAME = host=YOUR-HOST port=5432 dbname=YOUR-DBNAME auth_user=YOUR-DB-USERNAME
 
 [pgbouncer]
 listen_addr = *
@@ -47,11 +51,24 @@ server_reset_query =
 Create `/etc/pgbouncer/userlist.txt` with:
 
 ```
-"USERNAME1" "PASSWORD1"
-"USERNAME2" "PASSWORD2"
+"USERNAME1" "md5PASSWORD1"
+"USERNAME2" "md5PASSWORD2"
 ```
 
-Use the same credentials as your database server.
+Use the same credentials as your database server, but instead of the password you'll need the md5 hash of the password. The md5 password hash is just the md5sum of `password + username` with the string `md5` prepended. For instance, to derive the hash for user `username1` with password `password`, you can do:
+
+```bash
+# ubuntu, debian, etc.
+echo -n "passwordusername1" | md5sum
+# macOS, openBSD, etc.
+md5 -s "passwordusername1"
+```
+
+If the above commands give you an output string like `d75bb2be2d7086c6148944261a00f605`, then the `/etc/pgbouncer/userlist.txt` file would look as follows:
+
+```
+"username1" "md5d75bb2be2d7086c6148944261a00f605"
+```
 
 ## Start the Service
 


### PR DESCRIPTION
I had a bear of a time getting this working, and it wasn't until I stumbled across [this section of the mastodon docs](https://github.com/tootsuite/documentation/blob/master/Running-Mastodon/PgBouncer-guide.md#configuring-userlisttxt) that I was finally able to connect to my RDS instance.